### PR TITLE
Don't check for DISPLAY on Mac OS X

### DIFF
--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/JavaFxProvider.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/JavaFxProvider.java
@@ -69,7 +69,7 @@ class JavaFxProvider extends Provider {
             // TODO: There's still a chance the user is connected via SSH or on Server Core...
             hasDesktop = true;
         }
-        else if (isLinux(osName) || isMac(osName)) {
+        else if (isLinux(osName)) {
             if (displayVariable != null) {
                 hasDesktop = true;
             }


### PR DESCRIPTION
I had the `DISPLAY` environment variable configured on my Mac but I hadn't noticed it wasn't standard.  It's probably safe to assume most Mac OS X users have a desktop environment.