### PR TITLE
Generate and attach javadoc JAR for aggregate project

### DIFF
--- a/oauth2-useragent-core/pom.xml
+++ b/oauth2-useragent-core/pom.xml
@@ -90,20 +90,6 @@
           </archive>
         </configuration>
       </plugin>
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <additionalparam>-quiet</additionalparam>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 

--- a/oauth2-useragent-core/pom.xml
+++ b/oauth2-useragent-core/pom.xml
@@ -64,6 +64,22 @@
         </executions>
       </plugin>
       <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <!-- The only artifacts we need are from the aggregator project, oauth2-useragent,
+         and the parent POM, so disable deployment here -->
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <!-- The only artifacts we need are from the aggregator project, oauth2-useragent,
+         and the parent POM, so disable installation here -->
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>

--- a/oauth2-useragent-javafx/pom.xml
+++ b/oauth2-useragent-javafx/pom.xml
@@ -54,6 +54,22 @@
           </archive>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <!-- The only artifacts we need are from the aggregator project, oauth2-useragent,
+         and the parent POM, so disable deployment here -->
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <!-- The only artifacts we need are from the aggregator project, oauth2-useragent,
+         and the parent POM, so disable installation here -->
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/oauth2-useragent-tester/pom.xml
+++ b/oauth2-useragent-tester/pom.xml
@@ -48,6 +48,22 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <!-- The only artifacts we need are from the aggregator project, oauth2-useragent,
+         and the parent POM, so disable deployment here -->
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <!-- The only artifacts we need are from the aggregator project, oauth2-useragent,
+         and the parent POM, so disable installation here -->
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/oauth2-useragent/pom.xml
+++ b/oauth2-useragent/pom.xml
@@ -115,6 +115,13 @@
             </configuration>
           </plugin>
           <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <attach>true</attach>
+              <sourcepath>${project.basedir}/../oauth2-useragent-core/src/main/java;${project.basedir}/../oauth2-useragent-javafx/src/main/java</sourcepath>
+            </configuration>
+          </plugin>
+          <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
             <executions>
               <execution>

--- a/oauth2-useragent/pom.xml
+++ b/oauth2-useragent/pom.xml
@@ -134,6 +134,7 @@
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
               <attach>true</attach>
+              <skip>false</skip>
               <sourcepath>${project.basedir}/../oauth2-useragent-core/src/main/java;${project.basedir}/../oauth2-useragent-javafx/src/main/java</sourcepath>
             </configuration>
           </plugin>

--- a/oauth2-useragent/pom.xml
+++ b/oauth2-useragent/pom.xml
@@ -55,6 +55,22 @@
 
     <plugins>
       <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <!-- The only artifacts we need are from the aggregator project, oauth2-useragent,
+         so disable deployment by default and only enable it for the aggregator (here) -->
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <!-- The only artifacts we need are from the aggregator project, oauth2-useragent,
+         so disable installation by default and only enable it for the aggregator (here) -->
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>

--- a/oauth2-useragent/pom.xml
+++ b/oauth2-useragent/pom.xml
@@ -57,7 +57,7 @@
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
         <!-- The only artifacts we need are from the aggregator project, oauth2-useragent,
-         so disable deployment by default and only enable it for the aggregator (here) -->
+         and the parent POM, so enable deployment here -->
         <configuration>
           <skip>false</skip>
         </configuration>
@@ -65,7 +65,7 @@
       <plugin>
         <artifactId>maven-install-plugin</artifactId>
         <!-- The only artifacts we need are from the aggregator project, oauth2-useragent,
-         so disable installation by default and only enable it for the aggregator (here) -->
+         and the parent POM, so enable installation here -->
         <configuration>
           <skip>false</skip>
         </configuration>

--- a/oauth2-useragent/pom.xml
+++ b/oauth2-useragent/pom.xml
@@ -133,6 +133,7 @@
           <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
+              <additionalparam>-quiet</additionalparam>
               <attach>true</attach>
               <skip>false</skip>
               <sourcepath>${project.basedir}/../oauth2-useragent-core/src/main/java;${project.basedir}/../oauth2-useragent-javafx/src/main/java</sourcepath>

--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,6 @@
   </distributionManagement>
 
   <properties>
-    <!-- The maven-source-plugin is activated during release, through the use of `-D performRelease=true`
-    ...but we don't want to use the maven-source-plugin so we simply tell it to not attach its outputs
-    by setting the 'attach' property.
-     https://maven.apache.org/plugins/maven-source-plugin/jar-mojo.html
-     -->
-    <attach>false</attach>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -209,6 +203,28 @@
           </checkstyleRules>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
           <logViolationsToConsole>true</logViolationsToConsole>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <!-- The maven-javadoc-plugin is activated during release, through the use of `-D performRelease=true`
+        ...but we don't want to use the maven-javadoc-plugin so we simply tell it to not attach its outputs
+        by setting the 'attach' parameter.
+         https://maven.apache.org/plugins/maven-javadoc-plugin/jar-mojo.html
+         -->
+        <configuration>
+          <attach>false</attach>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+        <!-- The maven-source-plugin is activated during release, through the use of `-D performRelease=true`
+        ...but we don't want to use the maven-source-plugin so we simply tell it to not attach its outputs
+        by setting the 'attach' parameter.
+         https://maven.apache.org/plugins/maven-source-plugin/jar-mojo.html
+         -->
+        <configuration>
+          <attach>false</attach>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,11 @@
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.7</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -203,6 +208,22 @@
           </checkstyleRules>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
           <logViolationsToConsole>true</logViolationsToConsole>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <!-- The only artifacts we need are from the aggregator project, oauth2-useragent,
+         so disable deployment by default (here) and only enable it for the aggregator -->
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <!-- The only artifacts we need are from the aggregator project, oauth2-useragent,
+         so disable installation by default (here) and only enable it for the aggregator -->
+        <configuration>
+          <skip>true</skip>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -213,17 +213,17 @@
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
         <!-- The only artifacts we need are from the aggregator project, oauth2-useragent,
-         so disable deployment by default (here) and only enable it for the aggregator -->
+         and the parent POM, so enable deployment here -->
         <configuration>
-          <skip>true</skip>
+          <skip>false</skip>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-install-plugin</artifactId>
         <!-- The only artifacts we need are from the aggregator project, oauth2-useragent,
-         so disable installation by default (here) and only enable it for the aggregator -->
+         and the parent POM, so enable installation here -->
         <configuration>
-          <skip>true</skip>
+          <skip>false</skip>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -229,23 +229,21 @@
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <!-- The maven-javadoc-plugin is activated during release, through the use of `-D performRelease=true`
-        ...but we don't want to use the maven-javadoc-plugin so we simply tell it to not attach its outputs
-        by setting the 'attach' parameter.
+        ...but we don't want to use the maven-javadoc-plugin so we disable it altogether here.
          https://maven.apache.org/plugins/maven-javadoc-plugin/jar-mojo.html
          -->
         <configuration>
-          <attach>false</attach>
+          <skip>true</skip>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
         <!-- The maven-source-plugin is activated during release, through the use of `-D performRelease=true`
-        ...but we don't want to use the maven-source-plugin so we simply tell it to not attach its outputs
-        by setting the 'attach' parameter.
+        ...but we don't want to use the maven-source-plugin so we disable it altogether.
          https://maven.apache.org/plugins/maven-source-plugin/jar-mojo.html
          -->
         <configuration>
-          <attach>false</attach>
+          <skipSource>true</skipSource>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Summary
=======
A bit of clean-up and re-work of the POMs to make sure we only install & deploy the needed artifacts and not those of intermediate projects.  Deploying to Maven central requires deploying `-sources` and `-javadoc` JARs so this pull request makes us satisfy the latter requirement (and then some).

Manual testing
==============
1. Ran `mvn clean deploy -D performRelease=true -P release` and confirmed that the parent project's artifact (the parent POM) was installed and deployed, as well as only the aggregate project/module was:
    1. Generating a `-javadoc` artifact
    2. Generating a `-sources` artifact
    3. Installing the JARs (and their PGP signatures) to the local cache
    4. Deploying the JARs (and their PGP signatures) to the snapshot repository
2. Temporarily configured the GCM4ML to point to version 0.5.5-SNAPSHOT of this library (which was installed/deployed in the previous step) and then rebuilt, including running the unit tests.
3. Cleared my local cache and rebuilt GCM4ML.  The SNAPSHOT artifacts were downloaded from the snapshot repository, except for `-sources` and `-javadoc` (these aren't automatically downloaded on purpose).  I then instructed Maven to go fetch the associated `-javadoc` and confirmed that my IDE (IntelliJ IDEA) was able to fetch & render documentation associated with the oauth2-useragent project, even in the absence of the associated source code.

Mission accomplished!