### PR TITLE
Ignore stderr when we call JavaFx provider first

### DIFF
--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/AuthorizationResponse.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/AuthorizationResponse.java
@@ -61,6 +61,10 @@ public class AuthorizationResponse {
             for (final String pair : pairs) {
                 final String[] nameAndValue = NAME_VALUE_SEPARATOR.split(pair, 2);
                 try {
+                    if (nameAndValue.length != 2) {
+                        throw new AuthorizationException("parsing_error", "Failed to parse server response", null, null);
+                    }
+
                     final String name = URLDecoder.decode(nameAndValue[0], UTF_8);
                     final String value = URLDecoder.decode(nameAndValue[1], UTF_8);
                     if (RESPONSE_CODE.equals(name)) {


### PR DESCRIPTION
The stderr maybe benign, but in its presence our process fails.
We should first try parse the stdout and if we could parse out a
correct authorization code from the stdout, then treat the error
more seriously.  Otherwise even if there are stderr, but the code
is retrieved, we should simply ignore it.