### PR TITLE
Add a package locator to find the location of our class

### DIFF
--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
@@ -7,6 +7,7 @@ import com.microsoft.alm.oauth2.useragent.subprocess.DefaultProcessFactory;
 import com.microsoft.alm.oauth2.useragent.subprocess.ProcessCoordinator;
 import com.microsoft.alm.oauth2.useragent.subprocess.TestableProcess;
 import com.microsoft.alm.oauth2.useragent.subprocess.TestableProcessFactory;
+import com.microsoft.alm.oauth2.useragent.utils.PackageLocator;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -82,8 +83,13 @@ public class UserAgentImpl implements UserAgent {
             provider = determineProvider(userAgentProvider);
         }
         provider.augmentProcessParameters(command, classPath);
-        // TODO: is this the best way to add our JAR?
-        classPath.add(System.getProperty("java.class.path"));
+
+        // Locate our class to add it to the classPath
+        final PackageLocator locator = new PackageLocator();
+        final File classPathEntryFile = locator.locatePackage(UserAgentImpl.class);
+        final String classPathEntry = classPathEntryFile.getAbsolutePath();
+        classPath.add(classPathEntry);
+
         addClassPathToCommand(classPath, command, PATH_SEPARATOR);
         command.add("com.microsoft.alm.oauth2.useragent." + provider.getClassName());
         command.add(methodName);

--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/utils/PackageLocator.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/utils/PackageLocator.java
@@ -37,17 +37,21 @@ public class PackageLocator {
         }
 
         // Inspired by http://stackoverflow.com/a/12733172
-        File classFilePath;
-        try {
-            classFilePath = getClasspathFromProtectionDomain(clazz);
-        } catch (final SecurityException ignored) {
+        File classFilePath = getClasspathFromProtectionDomain(clazz);
+        if (classFilePath == null) {
             classFilePath = getClasspathFromResource(clazz);
         }
         return classFilePath;
     }
 
     private File getClasspathFromProtectionDomain(final Class clazz) throws SecurityException {
-        final ProtectionDomain protectionDomain = classPropertyAccessor.getProtectionDomain(clazz);
+        ProtectionDomain protectionDomain;
+        try {
+            protectionDomain = classPropertyAccessor.getProtectionDomain(clazz);
+        }
+        catch (final SecurityException ignored) {
+            return null;
+        }
         if (protectionDomain == null) {
             throw new Error("Unable to determine the ProtectionDomain for the specified class");
         }

--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/utils/PackageLocator.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/utils/PackageLocator.java
@@ -61,7 +61,7 @@ public class PackageLocator {
         }
         final URL resourceUrl = codeSource.getLocation();
         if (resourceUrl == null) {
-            throw new Error("CodeSource returned a null location URL");
+            return null;
         }
 
         final String canonicalName = classPropertyAccessor.getCanonicalName(clazz);

--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/utils/PackageLocator.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/utils/PackageLocator.java
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.oauth2.useragent.utils;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+import java.util.regex.Pattern;
+
+public class PackageLocator {
+
+    private static final Pattern PATTERN_DOT = Pattern.compile("\\.");
+
+    private final ClassPropertyAccessor classPropertyAccessor;
+
+    public PackageLocator() {
+        this(new ClassPropertyAccessor());
+    }
+
+    PackageLocator(final ClassPropertyAccessor classPropertyAccessor) {
+        this.classPropertyAccessor = classPropertyAccessor;
+    }
+
+    /**
+     * Determines the path to the package that contains the specified class.
+     *
+     * @param  clazz the class to be located
+     * @return a {@link File} representing the archive (jar or zip) or folder that contains this class
+     */
+    public File locatePackage(final Class clazz) {
+        if (clazz == null) {
+            throw new IllegalArgumentException("clazz was null");
+        }
+
+        // Inspired by http://stackoverflow.com/a/12733172
+        File classFilePath;
+        try {
+            classFilePath = getClasspathFromProtectionDomain(clazz);
+        } catch (final SecurityException ignored) {
+            classFilePath = getClasspathFromResource(clazz);
+        }
+        return classFilePath;
+    }
+
+    private File getClasspathFromProtectionDomain(final Class clazz) throws SecurityException {
+        final ProtectionDomain protectionDomain = classPropertyAccessor.getProtectionDomain(clazz);
+        if (protectionDomain == null) {
+            throw new Error("Unable to determine the ProtectionDomain for the specified class");
+        }
+        final CodeSource codeSource = protectionDomain.getCodeSource();
+        if (codeSource == null) {
+            throw new Error("ProtectionDomain returned a null CodeSource");
+        }
+        final URL resourceUrl = codeSource.getLocation();
+        if (resourceUrl == null) {
+            throw new Error("CodeSource returned a null location URL");
+        }
+
+        final String canonicalName = classPropertyAccessor.getCanonicalName(clazz);
+
+        final File result = getClasspathFromUrl(resourceUrl, canonicalName);
+
+        return result;
+    }
+
+    private File getClasspathFromResource(final Class clazz) {
+
+        final String name = classPropertyAccessor.getSimpleName(clazz) + ".class";
+        final URL resourceUrl = classPropertyAccessor.getResource(clazz, name);
+        if (resourceUrl == null) {
+            throw new Error("A null resource URL was returned by getResource");
+        }
+
+        final String canonicalName = classPropertyAccessor.getCanonicalName(clazz);
+
+        final File result = getClasspathFromUrl(resourceUrl, canonicalName);
+
+        return result;
+    }
+
+    static File getClasspathFromUrl(final URL resourceUrl, final String canonicalName) {
+        if (resourceUrl == null) {
+            throw new IllegalArgumentException("resourceUrl must not be null");
+        }
+        if (canonicalName == null) {
+            throw new IllegalArgumentException("canonicalName must not be null");
+        }
+
+        String resourcePath;
+        try {
+            final URI resourceUri = resourceUrl.toURI();
+            final URI schemeStrippedUri = stripSchemes(resourceUri);
+            resourcePath = schemeStrippedUri.getPath();
+        }
+        catch (final URISyntaxException ignored) {
+            // inspired by Kohsuke's blog post:
+            // https://community.oracle.com/blogs/kohsuke/2007/04/25/how-convert-javaneturl-javaiofile
+            resourcePath = resourceUrl.getPath();
+        }
+
+        final String slashedName = PATTERN_DOT.matcher(canonicalName).replaceAll("/");
+        final String pathToClassFile = "/" + slashedName + ".class";
+        final int lastIndexOfClassName = resourcePath.lastIndexOf(pathToClassFile);
+
+        final File result;
+        if (lastIndexOfClassName > 0) {
+            // remove the trailing ! as well
+            final int mark = resourcePath.charAt(lastIndexOfClassName - 1) == '!'
+                    ? lastIndexOfClassName - 1
+                    : lastIndexOfClassName;
+            final String resourcePathMinusSuffix = resourcePath.substring(0, mark);
+            result = new File(resourcePathMinusSuffix);
+        }
+        else {
+            result = new File(resourcePath);
+        }
+
+        return result;
+    }
+
+    /**
+     * Removes all the schemes from the specified {@link URI}.
+     *
+     * For example, given {@code jar:file:/PATH/xyz.jar!/classpath.class}, the output should be
+     * {@code /PATH/xyz.jar!/classpath.class}.
+     *
+     * @param uri a {@link URI} which has zero or more schemes
+     * @return a {@link URI} which has zero schemes
+     */
+    static URI stripSchemes(final URI uri) {
+        URI schemeStrippedUri = uri;
+        while (schemeStrippedUri.getScheme() != null) {
+            schemeStrippedUri = URI.create(schemeStrippedUri.getRawSchemeSpecificPart());
+        }
+        return schemeStrippedUri;
+    }
+
+    static class ClassPropertyAccessor {
+        public ProtectionDomain getProtectionDomain(final Class clazz) throws SecurityException {
+            return clazz.getProtectionDomain();
+        }
+
+        public URL getResource(final Class clazz, final String resourceName) {
+            return clazz.getResource(resourceName);
+        }
+
+        public String getCanonicalName(final Class clazz) {
+            return clazz.getCanonicalName();
+        }
+
+        public String getSimpleName(final Class clazz) {
+            return clazz.getSimpleName();
+        }
+    }
+}

--- a/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/utils/PackageLocatorTest.java
+++ b/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/utils/PackageLocatorTest.java
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.oauth2.useragent.utils;
+
+import com.microsoft.alm.oauth2.useragent.Provider;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URL;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PackageLocatorTest {
+
+    private Class testClazz;
+    private PackageLocator.ClassPropertyAccessor classPropertyAccessorMock;
+    private PackageLocator underTest;
+
+    @Before public void setup() {
+        testClazz = this.getClass();
+
+        classPropertyAccessorMock = mock(PackageLocator.ClassPropertyAccessor.class);
+        when(classPropertyAccessorMock.getSimpleName(testClazz)).thenReturn(testClazz.getSimpleName());
+
+        underTest = new PackageLocator(classPropertyAccessorMock);
+    }
+
+    @Test public void stripSchemes_zeroSchemes() throws Exception {
+        final URI uri = URI.create("/PATH.xyz.jar");
+
+        final URI actual = PackageLocator.stripSchemes(uri);
+
+        Assert.assertEquals(URI.create("/PATH.xyz.jar"), actual);
+    }
+
+    @Test public void stripSchemes_oneScheme() throws Exception {
+        final URI uri = URI.create("file:/PATH.xyz.jar");
+
+        final URI actual = PackageLocator.stripSchemes(uri);
+
+        Assert.assertEquals(URI.create("/PATH.xyz.jar"), actual);
+    }
+
+    @Test public void stripSchemes_oneSchemeWithJarBoundary() throws Exception {
+        final URI uri = URI.create("file:/PATH.xyz.jar!/classpath.class");
+
+        final URI actual = PackageLocator.stripSchemes(uri);
+
+        Assert.assertEquals(URI.create("/PATH.xyz.jar!/classpath.class"), actual);
+    }
+
+    @Test public void stripSchemes_twoSchemes() throws Exception {
+        final URI uri = URI.create("jar:file:/PATH.xyz.jar!/classpath.class");
+
+        final URI actual = PackageLocator.stripSchemes(uri);
+
+        Assert.assertEquals(URI.create("/PATH.xyz.jar!/classpath.class"), actual);
+    }
+
+    @Test public void locatePackage_fallbackToJarResourceOnSecurityException() throws Exception {
+        final URL url
+                = new URL("jar:file:/abc/def.jar!/com/microsoft/alm/oauth2/useragent/utils/PackageLocatorTest.class");
+
+        when(classPropertyAccessorMock.getProtectionDomain(testClazz)).thenThrow(new SecurityException());
+        when(classPropertyAccessorMock.getResource(testClazz, testClazz.getSimpleName() + ".class")).thenReturn(url);
+        when(classPropertyAccessorMock.getCanonicalName(testClazz)).thenReturn(testClazz.getCanonicalName());
+
+        final File actual = underTest.locatePackage(testClazz);
+
+        assertEquals("/abc/def.jar", actual);
+    }
+
+    @Test public void locatePackage_fallbackToWindowsResourcePathOnSecurityException() throws Exception {
+        final URL url
+                = new URL("file:/E:/windowsPath/Test/com/microsoft/alm/oauth2/useragent/utils/PackageLocatorTest.class");
+
+        when(classPropertyAccessorMock.getProtectionDomain(testClazz)).thenThrow(new SecurityException());
+        when(classPropertyAccessorMock.getResource(testClazz, testClazz.getSimpleName() + ".class")).thenReturn(url);
+        when(classPropertyAccessorMock.getCanonicalName(testClazz)).thenReturn(testClazz.getCanonicalName());
+
+        final File actual = underTest.locatePackage(testClazz);
+
+        assertEquals("/E:/windowsPath/Test", actual);
+    }
+
+    @Test public void locatePackage_favorProtectionDomain() throws Exception {
+        when(classPropertyAccessorMock.getProtectionDomain(testClazz)).thenReturn(testClazz.getProtectionDomain());
+        when(classPropertyAccessorMock.getCanonicalName(testClazz)).thenReturn(testClazz.getCanonicalName());
+
+        final File actual = underTest.locatePackage(testClazz);
+
+        // Unit tests are compiled into a "test-classes" folder
+        Assert.assertTrue(actual.getAbsolutePath().endsWith("test-classes"));
+    }
+
+    @Test public void getClasspathFromUrl_doesNotContainClass() throws Exception {
+        final URL url
+                = new URL("file:/E:/a%20b/c%26d/");
+        final String canonicalName = "com.microsoft.alm.oauth2.useragent.utils.PackageLocatorTest";
+
+        final File actual = PackageLocator.getClasspathFromUrl(url, canonicalName);
+
+        assertEquals("/E:/a b/c&d", actual);
+    }
+
+    @Test public void getClasspathFromUrl_encodedCharactersInURL() throws Exception {
+        final URL url
+            = new URL("file:/E:/a%20b/c%26d/com/microsoft/alm/oauth2/useragent/utils/PackageLocatorTest.class");
+        final String canonicalName = "com.microsoft.alm.oauth2.useragent.utils.PackageLocatorTest";
+
+        final File actual = PackageLocator.getClasspathFromUrl(url, canonicalName);
+
+        assertEquals("/E:/a b/c&d", actual);
+    }
+
+    @Test public void getClasspathFromUrl_spaceAndPlusInURL() throws Exception {
+        final URL url
+            = new URL("file:///c:/Documents and+Settings/User/com/microsoft/alm/oauth2/useragent/utils/PackageLocatorTest.class");
+        final String canonicalName = "com.microsoft.alm.oauth2.useragent.utils.PackageLocatorTest";
+
+        final File actual = PackageLocator.getClasspathFromUrl(url, canonicalName);
+
+        assertEquals("/c:/Documents and+Settings/User", actual);
+    }
+
+    private void assertEquals(final String expectedPath, final File actual) {
+        final String expectedOsSpecificPath = toOSSpecific(expectedPath);
+        final String actualPath = actual.getAbsolutePath();
+
+        Assert.assertEquals(expectedOsSpecificPath, actualPath);
+    }
+
+    private String toOSSpecific(final String unixFormattedName) {
+        String massaged = unixFormattedName;
+
+        if (Provider.isWindows(System.getProperty("os.name"))) {
+            // On windows, we need to remove the starting / and convert slashes
+            if (massaged.startsWith("/")) {
+                massaged = massaged.substring(1); // remove starting /
+            }
+
+            // Add the current drive letter if there is no drive
+            if (massaged.charAt(1) != ':') {
+                massaged = new File("/").getAbsolutePath() + massaged;
+            }
+
+            return massaged.replace("/", "\\");
+
+        }
+
+        return unixFormattedName;
+    }
+}


### PR DESCRIPTION
This pull request attempts to fix issue #9.

## Description:
When trying to utilize this oauth2-useragent library in our VSTS-IntelliJ plugin, we have realized the we weren't able to locate the launch any providers because the oauth2-useragent jar file is not on classpath -- IntelliJ uses plugin classloaders.  

This results in no browser windows are coming up, and authentication just fails.

## Solution
This pull request attempt to locate the oauth2-useragent jar from two different approaches:
1. From ProtectionDomain of the UserAgentImpl class, get its CodeSource location.
2. Get the UserAgentImpl resource from its classloader, and try to parse the jar or folder that contains the package.

## Manual testing
1. Manually replace the oauth2-useragent jar inside the IntelliJ plugin zip file. 
2. Install the new modified plugin.
3. Set a JVM option -DuseJavaFxAuthLibrary=true, and start IntelliJ
3. Verify the browser windows comes up when clicked on "Sign in" from checkout or import dialog.
