### PR TITLE
Relay the Java networking system properties to sub-processes to support proxy servers

### DIFF
--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
@@ -110,6 +110,8 @@ public class UserAgentImpl implements UserAgent {
         }
         provider.augmentProcessParameters(command, classPath);
 
+        relayProperties(System.getProperties(), NETWORKING_PROPERTY_NAMES, command);
+
         // Locate our class to add it to the classPath
         final PackageLocator locator = new PackageLocator();
         final File classPathEntryFile = locator.locatePackage(UserAgentImpl.class);

--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -39,9 +40,34 @@ public class UserAgentImpl implements UserAgent {
     static final String UTF_8 = "UTF-8";
 
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
+    private static final Set<String> NETWORKING_PROPERTY_NAMES;
     private static final Map<String, String> SAFE_REPLACEMENTS;
 
     static {
+        // http://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html
+        final Set<String> networkingPropertyNames = new HashSet<String>();
+        // HTTP
+        networkingPropertyNames.add("http.proxyHost");
+        networkingPropertyNames.add("http.proxyPort");
+        networkingPropertyNames.add("http.nonProxyHosts");
+
+        // HTTPS
+        networkingPropertyNames.add("https.proxyHost");
+        networkingPropertyNames.add("https.proxyPort");
+
+        // SOCKS
+        networkingPropertyNames.add("socksProxyHost");
+        networkingPropertyNames.add("socksProxyPort");
+        networkingPropertyNames.add("socksProxyVersion");
+        networkingPropertyNames.add("java.net.socks.username");
+        networkingPropertyNames.add("java.net.socks.password");
+
+        networkingPropertyNames.add("java.net.useSystemProxies");
+
+        // Misc HTTP properties
+        networkingPropertyNames.add("http.auth.ntlm.domain");
+        NETWORKING_PROPERTY_NAMES = Collections.unmodifiableSet(networkingPropertyNames);
+
         final HashMap<String, String> map = new HashMap<String, String>();
         map.put("+", " ");
         map.put("%28", "(");

--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
@@ -248,7 +248,7 @@ public class UserAgentImpl implements UserAgent {
             final String encodedKey = sortOfUrlEncode(key);
 
             final String value = (String) pairs.get(key);
-            final String encodedValue = sortOfUrlEncode(value);
+            final String encodedValue = value == null ? "" : sortOfUrlEncode(value);
 
             destination.append(encodedKey).append('=').append(encodedValue).append(NEW_LINE);
         }

--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
@@ -116,6 +116,15 @@ public class UserAgentImpl implements UserAgent {
         }
     }
 
+    static void relayProperties(final Properties properties, final Set<String> propertyNames, final List<String> destinationCommand) {
+        for (final String propertyName : propertyNames) {
+            final String propertyValue = properties.getProperty(propertyName);
+            if (propertyValue != null) {
+                destinationCommand.add("-D" + propertyName + "=" + propertyValue);
+            }
+        }
+    }
+
     void addClassPathToCommand(final List<String> classPath, final List<String> command, final String pathSeparator) {
         command.add("-classpath");
         //noinspection ToArrayCallWithZeroLengthArrayArgument

--- a/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/UserAgentImplTest.java
+++ b/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/UserAgentImplTest.java
@@ -146,6 +146,22 @@ public class UserAgentImplTest {
         );
     }
 
+    @Test public void appendPairs_nullValue() throws Exception {
+        final StringBuilder sb = new StringBuilder();
+        final LinkedHashMap<String, String> variables = new LinkedHashMap<String, String>();
+        variables.put("HOME", null);
+
+        UserAgentImpl.appendPairs(variables.keySet(), variables, sb, "BEGIN", "END");
+
+        assertLinesEqual(sb.toString(),
+                "BEGIN",
+                "",
+                "HOME=",
+                "",
+                "END"
+        );
+    }
+
     private static void assertLinesEqual(final String actual, final String... expectedLines) {
         final StringReader sr = new StringReader(actual);
         try {

--- a/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/UserAgentImplTest.java
+++ b/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/UserAgentImplTest.java
@@ -18,8 +18,10 @@ import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Properties;
@@ -179,6 +181,28 @@ public class UserAgentImplTest {
         finally {
             sr.close();
         }
+    }
+
+    @Test public void relayProperties_typical() throws Exception {
+        final HashSet<String> propertyNames = new HashSet<String>(Arrays.asList("http.proxyHost", "http.proxyPort"));
+        final Properties properties = new Properties();
+        properties.setProperty("http.proxyHost", "192.0.2.42");
+        final List<String> commands = new ArrayList<String>();
+
+        UserAgentImpl.relayProperties(properties, propertyNames, commands);
+
+        Assert.assertEquals(1, commands.size());
+        Assert.assertEquals("-Dhttp.proxyHost=192.0.2.42", commands.get(0));
+    }
+
+    @Test public void relayProperties_noneSet() throws Exception {
+        final HashSet<String> propertyNames = new HashSet<String>(Arrays.asList("http.proxyHost", "http.proxyPort"));
+        final Properties properties = new Properties();
+        final List<String> commands = new ArrayList<String>();
+
+        UserAgentImpl.relayProperties(properties, propertyNames, commands);
+
+        Assert.assertEquals(0, commands.size());
     }
 
     @Test public void determineProvider_Compatible() {

--- a/oauth2-useragent-javafx/src/test/java/com/microsoft/alm/oauth2/useragent/JavaFxTest.java
+++ b/oauth2-useragent-javafx/src/test/java/com/microsoft/alm/oauth2/useragent/JavaFxTest.java
@@ -27,10 +27,8 @@ public class JavaFxTest {
 
     private static final String INSECURE_PROTOCOL = "https";
     private static final String HOST = "localhost";
-    private static final int PORT = 8089;
-    private static final int INSECURE_PORT = 9443;
 
-    @Rule public WireMockRule wireMockRule = new WireMockRule(PORT, INSECURE_PORT);
+    @Rule public WireMockRule wireMockRule = new WireMockRule(0, 0);
 
     private final AtomicReference<Exception> expectedExceptionRef = new AtomicReference<>();
     private final AtomicReference<Exception> actualExceptionRef = new AtomicReference<>();
@@ -104,8 +102,9 @@ public class JavaFxTest {
     @Category(IntegrationTests.class)
     @Test public void insecureWiremock() throws URISyntaxException, AuthorizationException {
         expectedExceptionRef.set(new AuthorizationException("load_error", "java.lang.Throwable: SSL handshake failed", null, null));
-        final URI authorizationEndpoint = new URI(INSECURE_PROTOCOL, null, HOST, INSECURE_PORT, "/oauth2/authorize", "response_type=code&client_id=insecureWiremock&state=chicken", null);
-        final URI redirectUri = new URI(INSECURE_PROTOCOL, null, HOST, INSECURE_PORT, "/finished", null, null);
+        final int insecurePort = wireMockRule.httpsPort();
+        final URI authorizationEndpoint = new URI(INSECURE_PROTOCOL, null, HOST, insecurePort, "/oauth2/authorize", "response_type=code&client_id=insecureWiremock&state=chicken", null);
+        final URI redirectUri = new URI(INSECURE_PROTOCOL, null, HOST, insecurePort, "/finished", null, null);
         stubFor(get(urlEqualTo(authorizationEndpoint.getPath() + "?" + authorizationEndpoint.getQuery()))
                 .willReturn(aResponse()
                         .withStatus(200)

--- a/oauth2-useragent-tester/pom.xml
+++ b/oauth2-useragent-tester/pom.xml
@@ -84,5 +84,10 @@
       <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.littleshoot</groupId>
+      <artifactId>littleproxy</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
+++ b/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
@@ -21,16 +21,16 @@ public class AppTest {
 
     private static final String PROTOCOL = "http";
     private static final String HOST = "localhost";
-    private static final int PORT = 8089;
 
-    @Rule public WireMockRule wireMockRule = new WireMockRule(PORT);
+    @Rule public WireMockRule wireMockRule = new WireMockRule(0);
 
     @Category(IntegrationTests.class)
     @Test public void main_wiremock() throws URISyntaxException, AuthorizationException {
-        final URI authorizationEndpoint = new URI(PROTOCOL, null, HOST, PORT, "/oauth2/authorize", "response_type=code&client_id=main_wiremock&state=chicken", null);
-        final URI authorizationConfirmation = new URI(PROTOCOL, null, HOST, PORT, "/oauth2/confirm", "state=chicken", null);
+        final int port = wireMockRule.port();
+        final URI authorizationEndpoint = new URI(PROTOCOL, null, HOST, port, "/oauth2/authorize", "response_type=code&client_id=main_wiremock&state=chicken", null);
+        final URI authorizationConfirmation = new URI(PROTOCOL, null, HOST, port, "/oauth2/confirm", "state=chicken", null);
         final String redirectingBody = String.format("<html><head><meta http-equiv='refresh' content='1; url=%1$s'></head><body>Redirecting to %1$s...</body></html>", authorizationConfirmation.toString());
-        final URI redirectUri = new URI(PROTOCOL, null, HOST, PORT, "/finished", "code=steak&state=chicken", null);
+        final URI redirectUri = new URI(PROTOCOL, null, HOST, port, "/finished", "code=steak&state=chicken", null);
         stubFor(get(urlEqualTo(authorizationEndpoint.getPath() + "?" + authorizationEndpoint.getQuery()))
                 .willReturn(aResponse()
                         .withStatus(200)

--- a/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
+++ b/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
@@ -9,8 +9,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
@@ -20,17 +22,18 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 public class AppTest {
 
     private static final String PROTOCOL = "http";
-    private static final String HOST = "localhost";
 
     @Rule public WireMockRule wireMockRule = new WireMockRule(0);
 
     @Category(IntegrationTests.class)
-    @Test public void main_wiremock() throws URISyntaxException, AuthorizationException {
+    @Test public void main_wiremock() throws URISyntaxException, AuthorizationException, UnknownHostException {
         final int port = wireMockRule.port();
-        final URI authorizationEndpoint = new URI(PROTOCOL, null, HOST, port, "/oauth2/authorize", "response_type=code&client_id=main_wiremock&state=chicken", null);
-        final URI authorizationConfirmation = new URI(PROTOCOL, null, HOST, port, "/oauth2/confirm", "state=chicken", null);
+        final InetAddress localHostAddress = InetAddress.getLocalHost();
+        final String host = localHostAddress.getHostName();
+        final URI authorizationEndpoint = new URI(PROTOCOL, null, host, port, "/oauth2/authorize", "response_type=code&client_id=main_wiremock&state=chicken", null);
+        final URI authorizationConfirmation = new URI(PROTOCOL, null, host, port, "/oauth2/confirm", "state=chicken", null);
         final String redirectingBody = String.format("<html><head><meta http-equiv='refresh' content='1; url=%1$s'></head><body>Redirecting to %1$s...</body></html>", authorizationConfirmation.toString());
-        final URI redirectUri = new URI(PROTOCOL, null, HOST, port, "/finished", "code=steak&state=chicken", null);
+        final URI redirectUri = new URI(PROTOCOL, null, host, port, "/finished", "code=steak&state=chicken", null);
         stubFor(get(urlEqualTo(authorizationEndpoint.getPath() + "?" + authorizationEndpoint.getQuery()))
                 .willReturn(aResponse()
                         .withStatus(200)

--- a/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/LoggingFiltersSourceAdapter.java
+++ b/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/LoggingFiltersSourceAdapter.java
@@ -44,6 +44,7 @@ public class LoggingFiltersSourceAdapter extends HttpFiltersSourceAdapter {
         return new HttpFiltersAdapter(originalRequest, ctx) {
             @Override public HttpResponse clientToProxyRequest(final HttpObject httpObject) {
                 requests.add((FullHttpRequest) httpObject);
+                //httpObject.
                 return /* "[return] null to continue processing as usual" */ null;
             }
 

--- a/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/LoggingFiltersSourceAdapter.java
+++ b/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/LoggingFiltersSourceAdapter.java
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.oauth2.useragent;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import org.littleshoot.proxy.HttpFilters;
+import org.littleshoot.proxy.HttpFiltersAdapter;
+import org.littleshoot.proxy.HttpFiltersSourceAdapter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LoggingFiltersSourceAdapter extends HttpFiltersSourceAdapter {
+
+    private final List<FullHttpRequest> requests = new ArrayList<FullHttpRequest>();
+    private final List<FullHttpResponse> responses = new ArrayList<FullHttpResponse>();
+
+    /*
+    https://github.com/adamfisk/LittleProxy
+    """
+    To enable aggregator and inflater you have to return a value greater than 0 in your
+    `HttpFiltersSource#get(Request/Response)BufferSizeInBytes()` methods.
+    This provides to you a `FullHttp(Request/Response)`
+    with the complete content in your filter uncompressed.
+    Otherwise you have to handle the chunks yourself.
+    """
+     */
+
+    @Override public int getMaximumRequestBufferSizeInBytes() {
+        return 10 * 1024 * 1024;
+    }
+
+    @Override public int getMaximumResponseBufferSizeInBytes() {
+        return 10 * 1024 * 1024;
+    }
+
+    @Override public HttpFilters filterRequest(final HttpRequest originalRequest, final ChannelHandlerContext ctx) {
+        return new HttpFiltersAdapter(originalRequest, ctx) {
+            @Override public HttpResponse clientToProxyRequest(final HttpObject httpObject) {
+                requests.add((FullHttpRequest) httpObject);
+                return /* "[return] null to continue processing as usual" */ null;
+            }
+
+            @Override public HttpObject serverToProxyResponse(final HttpObject httpObject) {
+                responses.add((FullHttpResponse) httpObject);
+                return /* [return] the unmodified HttpObject */ httpObject;
+            }
+        };
+    }
+
+    public boolean proxyWasUsed() {
+        return requests.size() > 0;
+    }
+
+    public void reset() {
+        requests.clear();
+        responses.clear();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,12 @@
         <version>1.57</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.littleshoot</groupId>
+        <artifactId>littleproxy</artifactId>
+        <version>1.1.0-beta1</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
# Summary

Without these changes, a program using this component would open a web browser that would not follow the same proxy server configuration as the program and thus would be unable to complete the OAuth 2.0 Authorization Code Flow when access to the authorization endpoint needed to be performed through a proxy server.  This is because oauth2-useragent uses sub-processes to launch web browsers and the network-related configuration of the parent process was not propagated to the child processes.

This pull request propagates the values of networking-related system properties to the sub-processes such that if the main program can reach resources through a proxy server, so will the web browsers used for OAuth 2.0 flows.

# Manual testing

1. Set up a proxy server on the LAN.
    * I installed [Polipo](http://www.pps.univ-paris-diderot.fr/~jch/software/polipo/) on `192.168.0.117`.  It's listening on all interfaces at port `8123`.
1. Temporarily update the [Git Credential Manager for Mac and Linux](https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux)'s pom.xml to point to the SNAPSHOT version of oauth2-useragent containing these changes.
1. Configure a VSTS account with 2-factor authentication.
1. For each of Windows 10, Mac OS X 10.10.5 and Fedora 22:
    1. Copy the SNAPSHOT build of GCM4ML containing these oauth2-useragent changes and configure Git to point to that version, enabling debug mode by setting `-Ddebug=true`.
    1. Configure the networking to prevent being able to reach web servers without going through a proxy server.
        * I did this by temporarily configuring the DHCP reservation to clear the `003 Router` option and then renewing the lease.
        * Running  `wget` yields `Network is unreachable` or `No route to host`.
    1. Clear or invalidate the saved credentials (if any) for the VSTS account, to force authentication.
        * Windows & Linux: I did this by renaming `insecureStore.xml` to `insecureStore.xml.old`.
        * Mac: I did this by deleting the corresponding Keychain entry.
    1. Run a `git clone` against a Git repo in the VSTS account.
        * Git fails saying it can't reach the host.
    1. Configure Git to use our proxy server by running:

        ```
        git config --global http.proxy http://192.168.0.117:8123
        ```
    1. Try the `git clone` again.
        * The GCM4ML emits the following:

            ```
            BaseVsoAuthentication::detectAuthority
                detected visualstudio.com, checking AAD vs MSA
                failed detection
                authority is basic
            ```
        ...which means it's unable to reach VSTS and so Git falls back to prompting for credentials.
    1. Update the `credential.helper` configuration to include the following:

        ```
        -Dhttps.proxyHost=192.168.0.117 -Dhttps.proxyPort=8123
        ```
    1. Try the `git clone` again.
        * Notice that this time, the GCM4ML "AAD vs MSA" check succeeds with `server has reponded` and the web browser is popped up to complete the authentication. :white_check_mark:
    1. Complete the authentication and notice the `git clone` succeeding.
    1. Windows & Linux ([Oracle documents this setting as only being available "\[on\] recent Windows systems and on Gnome 2.x systems"](http://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html))
        1. Update the `credential.helper` configuration to replace the two `https.proxy*` properties with the following:

            ```
            -Djava.net.useSystemProxies=true
            ```
        1. Configure the proxy server for the operating system. 
        1. Clear or invalidate the saved credentials for the VSTS account, to force authentication.
        1. Run `git fetch` inside the local copy of the Git repository.
            * Notice that the GCM4ML "AAD vs MSA" check succeeds again, the web browser again is popped up and, after completing the authentication, Git indeed communicates with the remote. :white_check_mark:
        1. Clear the proxy server configuration for the operating system.
    1. Undo the Git `http.proxy` configuration.
    1. Undo the networking configuration, so as to restore direct access to web servers.

Mission accomplished!
