### PR TITLE
Separate machine-readable and human-readable representations of AuthorizationException

### DIFF
--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/AuthorizationException.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/AuthorizationException.java
@@ -27,6 +27,9 @@ public class AuthorizationException extends Exception {
 
     public AuthorizationException(final String code, final String description, final URI uri, final Throwable cause) {
         super(code, cause);
+        if (code == null) {
+            throw new IllegalArgumentException("The 'code' argument cannot be null.");
+        }
         this.code = code;
         this.description = description;
         this.uri = uri;

--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/AuthorizationException.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/AuthorizationException.java
@@ -48,7 +48,16 @@ public class AuthorizationException extends Exception {
     }
 
     @Override public String toString() {
-        return toString(this.code, this.description, this.uri);
+        final StringBuilder sb = new StringBuilder();
+        sb.append(getClass().getName()).append(": ");
+        sb.append("Code: ").append(code);
+        if (uri != null) {
+            sb.append(" Uri: ").append(uri.toString());
+        }
+        if (description != null) {
+            sb.append(" Description: ").append(description);
+        }
+        return sb.toString();
     }
 
     public static String toString(final String code, final Throwable throwable, final URI uri) {

--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
@@ -348,7 +348,7 @@ public class UserAgentImpl implements UserAgent, ProviderScanner {
             }
         }
         catch (final AuthorizationException e) {
-            printStream.println(e.toString());
+            printStream.println(AuthorizationException.toString(e.getCode(), e.getDescription(), e.getUri()));
         }
         catch (final IOException e) {
             printStream.println(AuthorizationException.toString("io_exception", e.getMessage(), null));

--- a/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/AuthorizationResponseTest.java
+++ b/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/AuthorizationResponseTest.java
@@ -32,7 +32,7 @@ public class AuthorizationResponseTest {
         try {
             AuthorizationResponse.fromString(input);
         } catch (final AuthorizationException actual) {
-            Assert.assertEquals("error=unknown_error", actual.toString());
+            Assert.assertEquals("unknown_error", actual.getCode());
             return;
         }
 

--- a/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/UserAgentImplTest.java
+++ b/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/UserAgentImplTest.java
@@ -223,6 +223,11 @@ public class UserAgentImplTest {
         );
     }
 
+    private static void assertLinesEqual(final String actual, final String expected) {
+        final String[] expectedLines = expected.split("\\n");
+        assertLinesEqual(actual, expectedLines);
+    }
+
     private static void assertLinesEqual(final String actual, final String... expectedLines) {
         final StringReader sr = new StringReader(actual);
         try {


### PR DESCRIPTION
This addresses issue #23 by modifying the `toString()` method of `AuthorizationException` to generate a human-readable representation, which is consistent with `Throwable`.  There was only one explicit call to `toString()` that needed the machine-readable version and it was updated to be consistent with other nearby calls (see 7671ebd).