### PR TITLE
Extract and expose useful methods for re-use

### DIFF
--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
@@ -215,6 +215,12 @@ public class UserAgentImpl implements UserAgent, ProviderScanner {
     }
 
     static void throwUnsupported(final Map<Provider, List<String>> unmetRequirements) {
+        final StringBuilder sb = buildUnsupportedMessage(unmetRequirements);
+
+        throw new IllegalStateException(sb.toString());
+    }
+
+    public static StringBuilder buildUnsupportedMessage(Map<Provider, List<String>> unmetRequirements) {
         final StringBuilder sb = new StringBuilder("I don't support your platform yet.");
         describeUnmetRequirements(unmetRequirements, sb);
         sb.append(NEW_LINE);
@@ -229,8 +235,7 @@ public class UserAgentImpl implements UserAgent, ProviderScanner {
 
         final Map<String, String> variables = System.getenv();
         appendVariables(variables, sb);
-
-        throw new IllegalStateException(sb.toString());
+        return sb;
     }
 
     static Provider scanProviders(final String userAgentProvider, final List<Provider> providers, final Map<Provider, List<String>> destinationUnmetRequirements, final boolean checkOverrideIsCompatible) {

--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
@@ -274,7 +274,7 @@ public class UserAgentImpl implements UserAgent, ProviderScanner {
         return result;
     }
 
-    static void describeUnmetRequirements(final Map<Provider, List<String>> unmetRequirements, final StringBuilder destination) {
+    public static void describeUnmetRequirements(final Map<Provider, List<String>> unmetRequirements, final StringBuilder destination) {
         for (final Map.Entry<Provider, List<String>> pair: unmetRequirements.entrySet()) {
             final Provider provider = pair.getKey();
             final List<String> requirements = pair.getValue();


### PR DESCRIPTION
Two small changes that enable me to reduce the amount of debug output by the GCM4ML when JavaFX isn't available, because we now have Device Flow on which to fallback.

Manual Testing
--------------

1. `mvn clean install`
2. In the GCM4ML POM, temporarily updated the `oauth2-useragent` dependency to version `0.8.2-SNAPSHOT`.
3. I was then able to call the new methods in the GCM4ML project, specifically in the `AzureAuthority` class.

Mission accomplished!