### PR TITLE
Enhance and repair functional tests

### DIFF
--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/utils/StringHelper.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/utils/StringHelper.java
@@ -12,6 +12,21 @@ public class StringHelper {
         return s1.equals(s2);
     }
 
+    public static boolean equalIgnoringCase(final String a, final String b) {
+        //noinspection StringEquality
+        if (a == b) {
+            return true;
+        }
+        if (a != null && b != null) {
+            int n = a.length();
+            if (b.length() != n) {
+                return false;
+            }
+            return a.regionMatches(true, 0, b, 0, n);
+        }
+        return false;
+    }
+
     public static String join(final String separator, final String[] value) {
         if (value == null)
             throw new IllegalArgumentException("value is null");

--- a/oauth2-useragent-javafx/src/main/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowser.java
+++ b/oauth2-useragent-javafx/src/main/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowser.java
@@ -97,8 +97,20 @@ class InterceptingBrowser extends Region implements ChangeListener<String> {
             return false;
         }
 
-        if (!StringHelper.equal(expectedUri.getPath(), actualUri.getPath())) {
-            return false;
+        final String actualPath = actualUri.getPath();
+        final String expectedPath = expectedUri.getPath();
+        if (actualPath != null) {
+            if (expectedPath == null) {
+                return false;
+            }
+            if (!actualPath.startsWith(expectedPath)) {
+                return false;
+            }
+        }
+        else {
+            if (expectedPath != null) {
+                return false;
+            }
         }
 
         return true;

--- a/oauth2-useragent-javafx/src/main/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowser.java
+++ b/oauth2-useragent-javafx/src/main/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowser.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.alm.oauth2.useragent;
 
+import com.microsoft.alm.oauth2.useragent.utils.StringHelper;
 import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
@@ -78,7 +79,29 @@ class InterceptingBrowser extends Region implements ChangeListener<String> {
     }
 
     static boolean matchesRedirection(final String expectedRedirectUriString, final String actualUriString) {
-        return (actualUriString != null && actualUriString.startsWith(expectedRedirectUriString));
+        if (actualUriString == null) {
+            return false;
+        }
+        final URI actualUri = URI.create(actualUriString);
+        final URI expectedUri = URI.create(expectedRedirectUriString);
+
+        if (!StringHelper.equalIgnoringCase(expectedUri.getScheme(), actualUri.getScheme())) {
+            return false;
+        }
+
+        if (!StringHelper.equalIgnoringCase(expectedUri.getHost(), actualUri.getHost())) {
+            return false;
+        }
+
+        if (expectedUri.getPort() != actualUri.getPort()) {
+            return false;
+        }
+
+        if (!StringHelper.equal(expectedUri.getPath(), actualUri.getPath())) {
+            return false;
+        }
+
+        return true;
     }
 
     public void sendRequest(final URI destinationUri, final URI redirectUri) {

--- a/oauth2-useragent-javafx/src/main/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowser.java
+++ b/oauth2-useragent-javafx/src/main/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowser.java
@@ -67,7 +67,7 @@ class InterceptingBrowser extends Region implements ChangeListener<String> {
     public void changed(final ObservableValue<? extends String> observable, final String oldValue, final String newValue) {
         lock.lock();
         try {
-            if (redirectUriString != null && newValue != null && newValue.startsWith(redirectUriString)) {
+            if (newValue != null && newValue.startsWith(redirectUriString)) {
                 response = UserAgentImpl.extractResponseFromRedirectUri(newValue);
                 responseReceived.signal();
             }

--- a/oauth2-useragent-javafx/src/main/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowser.java
+++ b/oauth2-useragent-javafx/src/main/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowser.java
@@ -67,7 +67,7 @@ class InterceptingBrowser extends Region implements ChangeListener<String> {
     public void changed(final ObservableValue<? extends String> observable, final String oldValue, final String newValue) {
         lock.lock();
         try {
-            if (newValue != null && newValue.startsWith(redirectUriString)) {
+            if (matchesRedirection(redirectUriString, newValue)) {
                 response = UserAgentImpl.extractResponseFromRedirectUri(newValue);
                 responseReceived.signal();
             }
@@ -75,6 +75,10 @@ class InterceptingBrowser extends Region implements ChangeListener<String> {
         finally {
             lock.unlock();
         }
+    }
+
+    static boolean matchesRedirection(final String expectedRedirectUriString, final String actualUriString) {
+        return (actualUriString != null && actualUriString.startsWith(expectedRedirectUriString));
     }
 
     public void sendRequest(final URI destinationUri, final URI redirectUri) {

--- a/oauth2-useragent-javafx/src/test/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowserTest.java
+++ b/oauth2-useragent-javafx/src/test/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowserTest.java
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.oauth2.useragent;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * A class to test {@link InterceptingBrowser}.
+ */
+public class InterceptingBrowserTest {
+
+}

--- a/oauth2-useragent-javafx/src/test/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowserTest.java
+++ b/oauth2-useragent-javafx/src/test/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowserTest.java
@@ -42,6 +42,16 @@ public class InterceptingBrowserTest {
     }
 
     @Test
+    public void matchesRedirection_expectedContainsQuery() throws Exception {
+        final String redirectUriString = "http://auth.example.com/success?state=chicken";
+        final String actualUriString = "http://auth.example.com/success?code=steak&state=chicken";
+
+        final boolean actual = InterceptingBrowser.matchesRedirection(redirectUriString, actualUriString);
+
+        Assert.assertEquals(true, actual);
+    }
+
+    @Test
     public void matchesRedirection_pathWithoutSlash() throws Exception {
         final String redirectUriString = "http://auth.example.com";
         final String actualUriString = "http://auth.example.com/";

--- a/oauth2-useragent-javafx/src/test/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowserTest.java
+++ b/oauth2-useragent-javafx/src/test/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowserTest.java
@@ -21,4 +21,14 @@ public class InterceptingBrowserTest {
         Assert.assertEquals(true, actual);
     }
 
+    @Test
+    public void matchesRedirection_hostIsCaseInsensitive() throws Exception {
+        final String redirectUriString = "http://Auth.example.com/success";
+        final String actualUriString = "http://auth.example.com/success?code=steak&state=chicken";
+
+        final boolean actual = InterceptingBrowser.matchesRedirection(redirectUriString, actualUriString);
+
+        Assert.assertEquals(true, actual);
+    }
+
 }

--- a/oauth2-useragent-javafx/src/test/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowserTest.java
+++ b/oauth2-useragent-javafx/src/test/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowserTest.java
@@ -11,4 +11,14 @@ import org.junit.Test;
  */
 public class InterceptingBrowserTest {
 
+    @Test
+    public void matchesRedirection_typical() throws Exception {
+        final String redirectUriString = "http://auth.example.com/success";
+        final String actualUriString = "http://auth.example.com/success?code=steak&state=chicken";
+
+        final boolean actual = InterceptingBrowser.matchesRedirection(redirectUriString, actualUriString);
+
+        Assert.assertEquals(true, actual);
+    }
+
 }

--- a/oauth2-useragent-javafx/src/test/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowserTest.java
+++ b/oauth2-useragent-javafx/src/test/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowserTest.java
@@ -31,4 +31,14 @@ public class InterceptingBrowserTest {
         Assert.assertEquals(true, actual);
     }
 
+    @Test
+    public void matchesRedirection_pathIsCaseSensitive() throws Exception {
+        final String redirectUriString = "http://auth.example.com/success";
+        final String actualUriString = "http://auth.example.com/Success?code=steak&state=chicken";
+
+        final boolean actual = InterceptingBrowser.matchesRedirection(redirectUriString, actualUriString);
+
+        Assert.assertEquals(false, actual);
+    }
+
 }

--- a/oauth2-useragent-javafx/src/test/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowserTest.java
+++ b/oauth2-useragent-javafx/src/test/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowserTest.java
@@ -41,4 +41,14 @@ public class InterceptingBrowserTest {
         Assert.assertEquals(false, actual);
     }
 
+    @Test
+    public void matchesRedirection_pathWithoutSlash() throws Exception {
+        final String redirectUriString = "http://auth.example.com";
+        final String actualUriString = "http://auth.example.com/";
+
+        final boolean actual = InterceptingBrowser.matchesRedirection(redirectUriString, actualUriString);
+
+        Assert.assertEquals(true, actual);
+    }
+
 }

--- a/oauth2-useragent-tester/src/main/java/com/microsoft/alm/oauth2/useragent/App.java
+++ b/oauth2-useragent-tester/src/main/java/com/microsoft/alm/oauth2/useragent/App.java
@@ -18,8 +18,18 @@ public class App
 
         final URI authorizationEndpoint = new URI(args[0]);
         final URI redirectUri = new URI(args[1]);
+        final String providerName = args.length >= 3 ? args[2] : null;
 
         final UserAgent userAgent = new UserAgentImpl();
+        if (providerName != null) {
+            final ProviderScanner providerScanner = (ProviderScanner) userAgent;
+            final Provider provider = providerScanner.findCompatibleProvider(providerName);
+            if (provider == null) {
+                final String template = "The '%s' provider is not available!";
+                final String message = String.format(template, providerName);
+                throw new UnsupportedOperationException(message);
+            }
+        }
 
         final AuthorizationResponse authorizationResponse = userAgent.requestAuthorizationCode(authorizationEndpoint, redirectUri);
 

--- a/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
+++ b/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
@@ -113,6 +113,7 @@ public class AppTest {
         final Properties tempProperties = new Properties(oldProperties);
         tempProperties.setProperty("http.proxyHost", localHostName);
         tempProperties.setProperty("http.proxyPort", proxyPort);
+        tempProperties.setProperty("http.nonProxyHosts", "localhost");
         System.setProperties(tempProperties);
 
         test_main_wiremock(providerName);

--- a/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
+++ b/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
@@ -28,6 +28,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 public class AppTest {
 
     private static final String PROTOCOL = "http";
+    private static final InetSocketAddress ALL_INTERFACES_AUTOMATIC_PORT =
+        new InetSocketAddress("0.0.0.0" /* all interfaces */, 0 /* automatic port */);
 
     @Rule public WireMockRule wireMockRule = new WireMockRule(0);
 
@@ -89,13 +91,10 @@ public class AppTest {
     @Category(IntegrationTests.class)
     @Test public void main_withProxyServerEnabled() throws URISyntaxException, AuthorizationException, UnknownHostException {
 
-        final String listenAddress = "0.0.0.0" /* all interfaces */;
-        final int listenPort = 0 /* automatic port */;
-        final InetSocketAddress requestedAddress = new InetSocketAddress(listenAddress, listenPort);
         final HttpProxyServer proxyServer =
             DefaultHttpProxyServer
                 .bootstrap()
-                .withAddress(requestedAddress)
+                .withAddress(ALL_INTERFACES_AUTOMATIC_PORT)
                 .withFiltersSource(adapter)
                 .start();
 
@@ -119,13 +118,10 @@ public class AppTest {
     @Category(IntegrationTests.class)
     @Test public void main_withProxyServerTunnellingTLS() throws URISyntaxException, AuthorizationException, UnknownHostException {
 
-        final String listenAddress = "0.0.0.0" /* all interfaces */;
-        final int listenPort = 0 /* automatic port */;
-        final InetSocketAddress requestedAddress = new InetSocketAddress(listenAddress, listenPort);
         final HttpProxyServer proxyServer =
                 DefaultHttpProxyServer
                         .bootstrap()
-                        .withAddress(requestedAddress)
+                        .withAddress(ALL_INTERFACES_AUTOMATIC_PORT)
                         .withFiltersSource(adapter)
                         .start();
 

--- a/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
+++ b/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
@@ -16,8 +16,6 @@ import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.UnknownHostException;
 import java.util.Properties;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -67,7 +65,7 @@ public class AppTest {
     }
 
     @Category(IntegrationTests.class)
-    @Test public void main_wiremock() throws URISyntaxException, AuthorizationException, UnknownHostException {
+    @Test public void main_wiremock() throws Exception {
         final URI authorizationEndpoint = new URI(PROTOCOL, null, localHostName, wireMockPort, "/oauth2/authorize", "response_type=code&client_id=main_wiremock&state=chicken", null);
         final URI authorizationConfirmation = new URI(PROTOCOL, null, localHostName, wireMockPort, "/oauth2/confirm", "state=chicken", null);
         final String redirectingBody = String.format("<html><head><meta http-equiv='refresh' content='1; url=%1$s'></head><body>Redirecting to %1$s...</body></html>", authorizationConfirmation.toString());
@@ -102,7 +100,7 @@ public class AppTest {
     }
 
     @Category(IntegrationTests.class)
-    @Test public void main_withProxyServerEnabled() throws URISyntaxException, AuthorizationException, UnknownHostException {
+    @Test public void main_withProxyServerEnabled() throws Exception {
 
         final Properties tempProperties = new Properties(oldProperties);
         tempProperties.setProperty("http.proxyHost", localHostName);
@@ -115,7 +113,7 @@ public class AppTest {
     }
 
     @Category(IntegrationTests.class)
-    @Test public void main_withProxyServerTunnellingTLS() throws URISyntaxException, AuthorizationException, UnknownHostException {
+    @Test public void main_withProxyServerTunnellingTLS() throws Exception {
 
         final Properties tempProperties = new Properties(oldProperties);
         tempProperties.setProperty("https.proxyHost", localHostName);

--- a/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
+++ b/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
@@ -28,6 +28,7 @@ public class AppTest {
     private static final String PROTOCOL = "http";
     private static final InetSocketAddress ALL_INTERFACES_AUTOMATIC_PORT =
         new InetSocketAddress("0.0.0.0" /* all interfaces */, 0 /* automatic port */);
+    private static final String JAVA_FX = Provider.JAVA_FX.getClassName();
 
     @Rule public WireMockRule wireMockRule = new WireMockRule(0);
 
@@ -65,7 +66,11 @@ public class AppTest {
     }
 
     @Category(IntegrationTests.class)
-    @Test public void main_wiremock() throws Exception {
+    @Test public void main_wiremock_JavaFX() throws Exception {
+        test_main_wiremock(JAVA_FX);
+    }
+
+    private void test_main_wiremock(final String providerName) throws Exception {
         final URI authorizationEndpoint = new URI(PROTOCOL, null, localHostName, wireMockPort, "/oauth2/authorize", "response_type=code&client_id=main_wiremock&state=chicken", null);
         final URI authorizationConfirmation = new URI(PROTOCOL, null, localHostName, wireMockPort, "/oauth2/confirm", "state=chicken", null);
         final String redirectingBody = String.format("<html><head><meta http-equiv='refresh' content='1; url=%1$s'></head><body>Redirecting to %1$s...</body></html>", authorizationConfirmation.toString());
@@ -85,7 +90,7 @@ public class AppTest {
                         .withStatus(200)
                         .withHeader("Content-Type", "text/html")
                         .withBody("Access granted, although you shouldn't see this message!")));
-        final String[] args = {authorizationEndpoint.toString(), redirectUri.toString()};
+        final String[] args = {authorizationEndpoint.toString(), redirectUri.toString(), providerName};
 
         try {
             App.main(args);
@@ -100,21 +105,27 @@ public class AppTest {
     }
 
     @Category(IntegrationTests.class)
-    @Test public void main_withProxyServerEnabled() throws Exception {
+    @Test public void main_withProxyServerEnabled_JavaFX() throws Exception {
+        test_main_withProxyServerEnabled(JAVA_FX);
+    }
 
+    private void test_main_withProxyServerEnabled(final String providerName) throws Exception {
         final Properties tempProperties = new Properties(oldProperties);
         tempProperties.setProperty("http.proxyHost", localHostName);
         tempProperties.setProperty("http.proxyPort", proxyPort);
         System.setProperties(tempProperties);
 
-        main_wiremock();
+        test_main_wiremock(providerName);
 
         Assert.assertTrue(adapter.proxyWasUsed());
     }
 
     @Category(IntegrationTests.class)
-    @Test public void main_withProxyServerTunnellingTLS() throws Exception {
+    @Test public void main_withProxyServerTunnellingTLS_JavaFX() throws Exception {
+        test_main_withProxyServerTunnellingTLS(JAVA_FX);
+    }
 
+    private void test_main_withProxyServerTunnellingTLS(final String providerName) throws Exception {
         final Properties tempProperties = new Properties(oldProperties);
         tempProperties.setProperty("https.proxyHost", localHostName);
         tempProperties.setProperty("http.proxyHost", localHostName);
@@ -122,7 +133,7 @@ public class AppTest {
         tempProperties.setProperty("http.proxyPort", proxyPort);
         System.setProperties(tempProperties);
 
-        final String[] args = {"https://visualstudio.com", "https://www.visualstudio.com"};
+        final String[] args = {"https://visualstudio.com", "https://www.visualstudio.com", providerName};
 
         boolean exceptionWasThrown = false;
         try {

--- a/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
+++ b/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
@@ -31,10 +31,13 @@ public class AppTest {
 
     @Rule public WireMockRule wireMockRule = new WireMockRule(0);
 
+    private final LoggingFiltersSourceAdapter adapter = new LoggingFiltersSourceAdapter();
+
     private Properties oldProperties;
 
     @Before
     public void setUp() throws Exception {
+        adapter.reset();
         oldProperties = System.getProperties();
         final Properties tempProperties = new Properties(oldProperties);
         System.setProperties(tempProperties);
@@ -85,7 +88,6 @@ public class AppTest {
 
     @Category(IntegrationTests.class)
     @Test public void main_withProxyServerEnabled() throws URISyntaxException, AuthorizationException, UnknownHostException {
-        final LoggingFiltersSourceAdapter adapter = new LoggingFiltersSourceAdapter();
 
         final String listenAddress = "0.0.0.0" /* all interfaces */;
         final int listenPort = 0 /* automatic port */;
@@ -116,7 +118,6 @@ public class AppTest {
 
     @Category(IntegrationTests.class)
     @Test public void main_withProxyServerTunnellingTLS() throws URISyntaxException, AuthorizationException, UnknownHostException {
-        final LoggingFiltersSourceAdapter adapter = new LoggingFiltersSourceAdapter();
 
         final String listenAddress = "0.0.0.0" /* all interfaces */;
         final int listenPort = 0 /* automatic port */;

--- a/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
+++ b/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
@@ -4,7 +4,9 @@
 package com.microsoft.alm.oauth2.useragent;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -28,6 +30,20 @@ public class AppTest {
     private static final String PROTOCOL = "http";
 
     @Rule public WireMockRule wireMockRule = new WireMockRule(0);
+
+    private Properties oldProperties;
+
+    @Before
+    public void setUp() throws Exception {
+        oldProperties = System.getProperties();
+        final Properties tempProperties = new Properties(oldProperties);
+        System.setProperties(tempProperties);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        System.setProperties(oldProperties);
+    }
 
     @Category(IntegrationTests.class)
     @Test public void main_wiremock() throws URISyntaxException, AuthorizationException, UnknownHostException {
@@ -69,7 +85,6 @@ public class AppTest {
 
     @Category(IntegrationTests.class)
     @Test public void main_withProxyServerEnabled() throws URISyntaxException, AuthorizationException, UnknownHostException {
-        final Properties oldProperties = System.getProperties();
         final LoggingFiltersSourceAdapter adapter = new LoggingFiltersSourceAdapter();
 
         final String listenAddress = "0.0.0.0" /* all interfaces */;
@@ -96,13 +111,11 @@ public class AppTest {
         }
         finally {
             proxyServer.stop();
-            System.setProperties(oldProperties);
         }
     }
 
     @Category(IntegrationTests.class)
     @Test public void main_withProxyServerTunnellingTLS() throws URISyntaxException, AuthorizationException, UnknownHostException {
-        final Properties oldProperties = System.getProperties();
         final LoggingFiltersSourceAdapter adapter = new LoggingFiltersSourceAdapter();
 
         final String listenAddress = "0.0.0.0" /* all interfaces */;
@@ -142,7 +155,6 @@ public class AppTest {
         }
         finally {
             proxyServer.stop();
-            System.setProperties(oldProperties);
         }
     }
 }


### PR DESCRIPTION
This pull request contains some refactoring to simplify the functional tests for re-use, PLUS some fixes to said tests on Mac OS X.

Manual testing
==============

Using Oracle JDK 8 x64 on each of:

1. Windows 10 (10.0.10586)
2. Mac OS X (10.10.5)
3. Fedora Linux (22)

...ran `mvn clean verify -Dintegration_tests=true` to confirm that all functional tests passed. (the JavaFX-based browser popped up 4 times on each platform)

Mission accomplished!