### PR TITLE
Users/yacao/urnredirectsupport

### DIFF
--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
@@ -156,6 +156,9 @@ public class UserAgentImpl implements UserAgent, ProviderScanner {
         final ArrayList<String> classPath = new ArrayList<String>();
         // TODO: should we append ".exe" on Windows?
         command.add(new File(JAVA_HOME, "bin/java").getAbsolutePath());
+
+        command.add("-Djava.protocol.handler.pkgs=com.microsoft.alm.oauth2.useragent");
+
         final String userAgentProvider = System.getProperty(USER_AGENT_PROVIDER_PROPERTY_NAME);
         findCompatibleProvider(userAgentProvider, false);
         if (provider == null) {

--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
@@ -18,8 +18,10 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -368,7 +370,14 @@ public class UserAgentImpl implements UserAgent, ProviderScanner {
     }
 
     static String extractResponseFromRedirectUri(final String redirectedUri) {
-        final URI uri = URI.create(redirectedUri);
-        return uri.getQuery();
+        final URL uri;
+        try {
+            uri = new URL(redirectedUri);
+            return uri.getQuery();
+        } catch (MalformedURLException e) {
+            //ignored
+        }
+
+        return null;
     }
 }

--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/urn/Handler.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/urn/Handler.java
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root.
+
+package com.microsoft.alm.oauth2.useragent.urn;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+
+public class Handler extends URLStreamHandler {
+
+    @Override
+    protected URLConnection openConnection(final URL u) throws IOException {
+        return new URLConnection(u) {
+            @Override
+            public void connect() throws IOException {
+                // void, there is nothing to connect to
+            }
+        };
+    }
+}

--- a/oauth2-useragent-javafx/src/main/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowser.java
+++ b/oauth2-useragent-javafx/src/main/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowser.java
@@ -30,6 +30,7 @@ class InterceptingBrowser extends Region implements ChangeListener<String> {
 
     public InterceptingBrowser() {
         webEngine.locationProperty().addListener(this);
+
         final Worker<Void> loadWorker = webEngine.getLoadWorker();
         loadWorker.stateProperty().addListener(new ChangeListener<Worker.State>() {
             public void changed(final ObservableValue<? extends Worker.State> observable, final Worker.State oldValue, final Worker.State newValue) {
@@ -82,6 +83,7 @@ class InterceptingBrowser extends Region implements ChangeListener<String> {
         if (actualUriString == null) {
             return false;
         }
+
         final URI actualUri = URI.create(actualUriString);
         final URI expectedUri = URI.create(expectedRedirectUriString);
 
@@ -111,6 +113,10 @@ class InterceptingBrowser extends Region implements ChangeListener<String> {
             if (expectedPath != null) {
                 return false;
             }
+        }
+
+        if (actualUri.getScheme().equals("urn") && !actualUriString.startsWith(expectedRedirectUriString)) {
+            return false;
         }
 
         return true;
@@ -148,4 +154,5 @@ class InterceptingBrowser extends Region implements ChangeListener<String> {
             lock.unlock();
         }
     }
+
 }

--- a/oauth2-useragent-javafx/src/test/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowserTest.java
+++ b/oauth2-useragent-javafx/src/test/java/com/microsoft/alm/oauth2/useragent/InterceptingBrowserTest.java
@@ -61,4 +61,24 @@ public class InterceptingBrowserTest {
         Assert.assertEquals(true, actual);
     }
 
+    @Test
+    public void matchesRedirection_urnSchemeWithNativeAppRedirect() throws Exception {
+        final String redirectUriString = "urn:ietf:wg:oauth:2.0:oob";
+        final String actualUriString = "urn:ietf:wg:oauth:2.0:oob?code=abc&stat=123";
+
+        final boolean actual = InterceptingBrowser.matchesRedirection(redirectUriString, actualUriString);
+
+        Assert.assertEquals(true, actual);
+    }
+
+
+    @Test
+    public void matchesRedirection_urnSchemeCaseSensitive() throws Exception {
+        final String redirectUriString = "urn:ietf:wg:oauth:2.0:oob";
+        final String actualUriString = "urn:IETF:wg:oauth:2.0:oob?code=abc&stat=123";
+
+        final boolean actual = InterceptingBrowser.matchesRedirection(redirectUriString, actualUriString);
+
+        Assert.assertEquals(false, actual);
+    }
 }

--- a/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
+++ b/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
@@ -77,6 +77,11 @@ public class AppTest {
         test_main_wiremock(STANDARD_WIDGET_TOOLKIT);
     }
 
+    @Category(IntegrationTests.class)
+    @Test public void nativeapp_wiremock_javafx() throws Exception {
+        test_main_native_app_wiremock(JAVA_FX);
+    }
+
     private void test_main_wiremock(final String providerName) throws Exception {
         final URI authorizationEndpoint = new URI(PROTOCOL, null, localHostName, wireMockPort, "/oauth2/authorize", "response_type=code&client_id=main_wiremock&state=chicken", null);
         final URI authorizationConfirmation = new URI(PROTOCOL, null, localHostName, wireMockPort, "/oauth2/confirm", "state=chicken", null);
@@ -109,6 +114,40 @@ public class AppTest {
         Assert.assertEquals("steak", App.code);
         Assert.assertEquals("chicken", App.state);
 
+    }
+
+    private void test_main_native_app_wiremock(final String providerName) throws Exception {
+        final URI authorizationEndpoint = new URI(PROTOCOL, null, localHostName, wireMockPort, "/oauth2/authorize", "response_type=code&client_id=main_wiremock&state=chicken", null);
+        final URI authorizationConfirmation = new URI(PROTOCOL, null, localHostName, wireMockPort, "/oauth2/confirm", "state=chicken", null);
+        final String redirectingBody = String.format("<html><head><meta http-equiv='refresh' content='1; url=%1$s'></head><body>Redirecting to %1$s...</body></html>", authorizationConfirmation.toString());
+        final String nativeAppRedirect = "urn:ietf:wg:oauth:2.0:oob";
+        final URI redirectUri = new URI(nativeAppRedirect + "?code=steak&state=chicken");
+        stubFor(get(urlEqualTo(authorizationEndpoint.getPath() + "?" + authorizationEndpoint.getQuery()))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/html")
+                        .withBody(redirectingBody)));
+        stubFor(get(urlEqualTo(authorizationConfirmation.getPath() + "?" + authorizationConfirmation.getQuery()))
+                .willReturn(aResponse()
+                        .withStatus(302)
+                        .withHeader("Location", redirectUri.toString())
+                        .withBody(redirectingBody)));
+        stubFor(get(urlEqualTo(redirectUri.getPath() + "?" + redirectUri.getQuery()))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/html")
+                        .withBody("Access granted, although you shouldn't see this message!")));
+        final String[] args = {authorizationEndpoint.toString(), nativeAppRedirect, providerName};
+
+        try {
+            App.main(args);
+        }
+        catch (final AuthorizationException e) {
+            Assert.fail(e.getMessage() + UserAgentImpl.NEW_LINE + e.getDescription());
+        }
+
+        Assert.assertEquals("steak", App.code);
+        Assert.assertEquals("chicken", App.state);
     }
 
     @Category(IntegrationTests.class)

--- a/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
+++ b/oauth2-useragent-tester/src/test/java/com/microsoft/alm/oauth2/useragent/AppTest.java
@@ -82,6 +82,11 @@ public class AppTest {
         test_main_native_app_wiremock(JAVA_FX);
     }
 
+    @Category(IntegrationTests.class)
+    @Test public void nativeapp_wiremock_swt() throws Exception {
+        test_main_native_app_wiremock(STANDARD_WIDGET_TOOLKIT);
+    }
+
     private void test_main_wiremock(final String providerName) throws Exception {
         final URI authorizationEndpoint = new URI(PROTOCOL, null, localHostName, wireMockPort, "/oauth2/authorize", "response_type=code&client_id=main_wiremock&state=chicken", null);
         final URI authorizationConfirmation = new URI(PROTOCOL, null, localHostName, wireMockPort, "/oauth2/confirm", "state=chicken", null);
@@ -132,11 +137,6 @@ public class AppTest {
                         .withStatus(302)
                         .withHeader("Location", redirectUri.toString())
                         .withBody(redirectingBody)));
-        stubFor(get(urlEqualTo(redirectUri.getPath() + "?" + redirectUri.getQuery()))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withHeader("Content-Type", "text/html")
-                        .withBody("Access granted, although you shouldn't see this message!")));
         final String[] args = {authorizationEndpoint.toString(), nativeAppRedirect, providerName};
 
         try {


### PR DESCRIPTION
Manual tests:
1. Register an AAD OAuth2 app with "urn:ietf:wg:oauth:2.0:oob" as redirect uri.
2. Run the App class in `oauth2-useragent-tester` package with this OAuth2 app

Verify both SWT and JavaFx is able to retrieve the authorization code.