### PR TITLE
TDD: version string with only major & minor

### DIFF
--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/Version.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/Version.java
@@ -11,7 +11,7 @@ public class Version
     private final static Pattern JAVA_RUNTIME_VERSION =
             Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)_(\\d+)-(?:.*-)?b(\\d+).*");
     private final static Pattern GENERIC_VERSION =
-            Pattern.compile("[^0-9]*(\\d+)\\.(\\d+)\\.(\\d+).*");
+            Pattern.compile("[^0-9]*(\\d+)\\.(\\d+)(?:\\.(\\d+))?.*");
     private final int major;
     private final int minor;
     private final int patch;
@@ -46,7 +46,10 @@ public class Version
     }
 
     /**
-     * Parses a generic string that contains a version number in the format major.minor.patch
+     * Parses a generic string that contains a version number in the format
+     * major.minor.patch
+     * or
+     * major.minor
      *
      * @param version String containing the version number
      * @return Version object with version details
@@ -56,7 +59,8 @@ public class Version
         Matcher matcher = getMatches(GENERIC_VERSION, version);
         int major = Integer.parseInt(matcher.group(1));
         int minor = Integer.parseInt(matcher.group(2));
-        int patch = Integer.parseInt(matcher.group(3));
+        final String patchString = matcher.group(3);
+        final int patch = patchString != null ? Integer.parseInt(patchString) : 0;
 
         return new Version(major, minor, patch, 0, 0);
     }

--- a/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/VersionTest.java
+++ b/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/VersionTest.java
@@ -50,6 +50,10 @@ public class VersionTest
         testGenericVersion(10, 10, 5, "10.10.5");
     }
 
+    @Test public void macOsVersionWithoutPatch() {
+        testGenericVersion(10, 11, 0, "10.11");
+    }
+
     private void testGenericVersion(final int major, final int minor, final int patch, final String input) {
         final Version version = Version.parseVersion(input);
         Assert.assertEquals(major, version.getMajor());


### PR DESCRIPTION
Found through the GCML4ML: sometimes the Mac OS X version is only `major.minor`, so made `patch` optional.

Manual testing
--------------

1. Added a few scenarios to a `ProgramTest#checkOsRequirements_macOsHappy()` for version strings like `10.11` and `10.12`.  The updated test failed.
2. Installed SNAPSHOT version in local Maven repository and then temporarily updated GCM4ML's POM to point to it.  The updated test now passed.

Mission accomplished!