### PR TITLE
Relax Java version parsing

### DIFF
--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/Version.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/Version.java
@@ -59,10 +59,13 @@ public class Version
         Matcher matcher = getMatches(GENERIC_VERSION, version);
         int major = Integer.parseInt(matcher.group(1));
         int minor = Integer.parseInt(matcher.group(2));
-        final String patchString = matcher.group(3);
-        final int patch = patchString != null ? Integer.parseInt(patchString) : 0;
+        int patch = integerOrZero(matcher.group(3));
 
         return new Version(major, minor, patch, 0, 0);
+    }
+
+    static int integerOrZero(final String input) {
+        return input != null ? Integer.parseInt(input) : 0;
     }
 
     /**

--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/Version.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/Version.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 public class Version
 {
     private final static Pattern JAVA_RUNTIME_VERSION =
-            Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)_(\\d+)-(?:.*-)?b(\\d+).*");
+            Pattern.compile("(\\d+)\\.(\\d+)(?:\\.(\\d+))?(?:_(\\d+))?(?:-(?:.*-)?b(\\d+))?.*");
     private final static Pattern GENERIC_VERSION =
             Pattern.compile("[^0-9]*(\\d+)\\.(\\d+)(?:\\.(\\d+))?.*");
     private final int major;
@@ -38,9 +38,9 @@ public class Version
         Matcher matcher = getMatches(JAVA_RUNTIME_VERSION, javaRuntimeVersion);
         int major = Integer.parseInt(matcher.group(1));
         int minor = Integer.parseInt(matcher.group(2));
-        int patch = Integer.parseInt(matcher.group(3));
-        int update = Integer.parseInt(matcher.group(4));
-        int build = Integer.parseInt(matcher.group(5));
+        int patch = integerOrZero(matcher.group(3));
+        int update = integerOrZero(matcher.group(4));
+        int build = integerOrZero(matcher.group(5));
 
         return new Version(major, minor, patch, update, build);
     }

--- a/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/VersionTest.java
+++ b/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/VersionTest.java
@@ -41,6 +41,22 @@ public class VersionTest
         testJdkParsing(1, 8, 0, 60, 27, "1.8.0_60-b27");
     }
 
+    @Test public void javaWithBuildNoUpdate() {
+        testJdkParsing(1, 8, 0, 0, 132, "1.8.0-b132");
+    }
+
+    @Test public void javaWithUpdateNoBuild() {
+        testJdkParsing(1, 8, 0, 3, 0, "1.8.0_3");
+    }
+
+    @Test public void javaWithNoBuildNoUpdate() {
+        testJdkParsing(1, 8, 0, 0, 0, "1.8.0");
+    }
+
+    @Test public void javaWithNoPatchNoUpdateNoBuild() {
+        testJdkParsing(1, 8, 0, 0, 0, "1.8");
+    }
+
     @Test public void gitVersion()
     {
         testGenericVersion(2, 4, 9, "git version 2.4.9 (Apple Git-60)");


### PR DESCRIPTION
Addresses issue #37 by making the `patch`, `update` and `build` components optional and default to `0` if they aren't specified.  See the tests for what's accepted and how it's interpreted.