### PR TITLE
Support Java 9+ Version Strings

### DIFF
--- a/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/VersionTest.java
+++ b/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/VersionTest.java
@@ -57,6 +57,18 @@ public class VersionTest
         testJdkParsing(1, 8, 0, 0, 0, "1.8");
     }
 
+    @Test public void java9MajorVersionFormat() {
+        testJdkParsing(10, 0, 0, 0, 46, "10+46");
+    }
+
+    @Test public void java9MinorVersionFormat() {
+        testJdkParsing(10, 1, 2, 0, 62, "10.1.2+62");
+    }
+
+    @Test public void java9EarlyAccessVersionFormat() {
+        testJdkParsing(10, 0, 0, 0, 73, "10-ea+73");
+    }
+
     @Test public void gitVersion()
     {
         testGenericVersion(2, 4, 9, "git version 2.4.9 (Apple Git-60)");
@@ -85,5 +97,4 @@ public class VersionTest
         Assert.assertEquals(update, version.getUpdate());
         Assert.assertEquals(build, version.getBuild());
     }
-
 }

--- a/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/VersionTest.java
+++ b/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/VersionTest.java
@@ -69,6 +69,10 @@ public class VersionTest
         testJdkParsing(10, 0, 0, 0, 73, "10-ea+73");
     }
 
+    @Test public void java9UbuntuVersionFormat() {
+        testJdkParsing(9, 1, 0, 0, 0, "9-Ubuntu+0-9b181-4");
+    }
+
     @Test public void gitVersion()
     {
         testGenericVersion(2, 4, 9, "git version 2.4.9 (Apple Git-60)");

--- a/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/VersionTest.java
+++ b/oauth2-useragent-core/src/test/java/com/microsoft/alm/oauth2/useragent/VersionTest.java
@@ -70,7 +70,7 @@ public class VersionTest
     }
 
     @Test public void java9UbuntuVersionFormat() {
-        testJdkParsing(9, 1, 0, 0, 0, "9-Ubuntu+0-9b181-4");
+        testJdkParsing(9, 0, 0, 0, 0, "9-Ubuntu+0-9b181-4");
     }
 
     @Test public void gitVersion()


### PR DESCRIPTION
Java 9 introduced a new format for the Java version string. This PR adds support for the new format and if there's no match will fall back to the previous version string format.

This fixes an issue surfaced in the Git Credential Manager which has this as a dependency: [Issue #74](https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux/issues/74)