### PR TITLE
Allow to override provider list in the UserAgentImpl

### DIFF
--- a/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
+++ b/oauth2-useragent-core/src/main/java/com/microsoft/alm/oauth2/useragent/UserAgentImpl.java
@@ -93,7 +93,11 @@ public class UserAgentImpl implements UserAgent, ProviderScanner {
     private String userAgentProvider = null;
 
     public UserAgentImpl() {
-        this(new DefaultProcessFactory(), null, Provider.PROVIDERS);
+        this(Provider.PROVIDERS);
+    }
+
+    public UserAgentImpl(final List<Provider> providers) {
+        this(new DefaultProcessFactory(), null, providers);
     }
 
     UserAgentImpl(final TestableProcessFactory processFactory, final Provider provider, final List<Provider> candidateProviders) {


### PR DESCRIPTION
This will allow the library users to provide their own set of providers if necessary.

It is critical for the DPI issue in the Azure DevOps plugin, see https://github.com/microsoft/azure-devops-intellij/issues/237 and https://github.com/microsoft/azure-devops-intellij/pull/238 for details.